### PR TITLE
Get sl to build on the latest version of Rust.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,5 +8,5 @@ dependencies = [
 [[package]]
 name = "ncurses"
 version = "5.71.1"
-source = "git+https://github.com/jeaye/ncurses-rs.git#5d9783fac92b4cb8b6219deda3a032be98b56a7d"
+source = "git+https://github.com/jeaye/ncurses-rs.git#89ad3e1b0879d734650d093780cc9751dea589da"
 

--- a/src/bin/sl.rs
+++ b/src/bin/sl.rs
@@ -57,10 +57,10 @@ trait Render : Train + Copy {
   fn render_line(&self, y: i32, x: i32, line: &str) {
     let paint_len = (ncurses::COLS - x) as uint;
     if paint_len < line.len() {
-      ncurses::mvaddstr(y, x, line[0..paint_len]);
+      ncurses::mvaddstr(y, x, &line[0..paint_len]);
     } else if x < 0 {
       if -x < line.len() as i32 {
-        ncurses::mvaddstr(y, 0, line[-x as uint..line.len()]);
+        ncurses::mvaddstr(y, 0, &line[-x as uint..line.len()]);
       }
     } else {
       ncurses::mvaddstr(y, x, line);
@@ -93,11 +93,11 @@ fn main() {
   };
 
   let train: Box<Render> = if matches.opt_present("l") {
-                             box Logo
+                             Box::new(Logo)
                            } else if matches.opt_present("c") {
-                             box C51
+                             Box::new(C51)
                            } else {
-                             box SL
+                             Box::new(SL)
                            };
 
 
@@ -105,7 +105,7 @@ fn main() {
   unsafe { signal(SIGINT, SIG_IGN); }
 
   ncurses::noecho();
-  ncurses::curs_set(ncurses::CURSOR_INVISIBLE);
+  ncurses::curs_set(ncurses::CURSOR_VISIBILITY::CURSOR_INVISIBLE);
   ncurses::nodelay(ncurses::stdscr, true);
   ncurses::leaveok(ncurses::stdscr, true);
   ncurses::scrollok(ncurses::stdscr, false);

--- a/src/c51.rs
+++ b/src/c51.rs
@@ -1,6 +1,7 @@
 use super::Train;
 use super::data::{C51WHL, C51BODY, COAL};
 
+#[derive(Copy)]
 pub struct C51;
 
 impl Train for C51 {

--- a/src/d51.rs
+++ b/src/d51.rs
@@ -1,6 +1,7 @@
 use super::Train;
 use super::data::{D51BODY, D51WHL, COAL};
 
+#[derive(Copy)]
 pub struct SL;
 
 impl Train for SL {

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,4 +1,4 @@
-pub static C51BODY: [&'static str, ..7] = [
+pub static C51BODY: [&'static str; 7] = [
   "        ___                                            ",
   "       _|_|_  _     __       __             ___________",
   "    D__/   \\_(_)___|  |__H__|  |_____I_Ii_()|_________|",
@@ -8,7 +8,7 @@ pub static C51BODY: [&'static str, ..7] = [
   "|    | _______|_::-----------------[][]-----|       |  ",
 ];
 
-pub static C51WHL: [[&'static str, ..4], ..6] = [
+pub static C51WHL: [[&'static str; 4]; 6] = [
   [
     "| /~~ ||   |-----/~~~~\\  /[I_____I][][] --|||_______|__",
     "------'|oOo|==[]=-     ||      ||      |  ||=======_|__",
@@ -47,7 +47,7 @@ pub static C51WHL: [[&'static str, ..4], ..6] = [
   ]
 ];
 
-pub static D51BODY: [&'static str, ..7] = [
+pub static D51BODY: [&'static str; 7] = [
  "      ====        ________                ___________ ",
  "  _D _|  |_______/        \\__I_I_____===__|_________| ",
  "   |(_)---  |   H\\________/ |   |        =|___ ___|   ",
@@ -57,7 +57,7 @@ pub static D51BODY: [&'static str, ..7] = [
  "  |/ |   |-----------I_____I [][] []  D   |=======|__ "
 ];
 
-pub static D51WHL: [[&'static str, ..3], ..6] = [
+pub static D51WHL: [[&'static str; 3]; 6] = [
   [
     "__/ =| o |=-~~\\  /~~\\  /~~\\  /~~\\ ____Y___________|__ ",
     " |/-=|___|=    ||    ||    ||    |_____/~\\___/        ",
@@ -90,7 +90,7 @@ pub static D51WHL: [[&'static str, ..3], ..6] = [
   ]
 ];
 
-pub static COAL: [&'static str, ..10] = [
+pub static COAL: [&'static str; 10] = [
   "                              ",
   "                              ",
   "    _________________         ",
@@ -103,14 +103,14 @@ pub static COAL: [&'static str, ..10] = [
   "    \\_/   \\_/    \\_/   \\_/    ",
 ];
 
-pub static LOGO: [&'static str, ..4] = [
+pub static LOGO: [&'static str; 4] = [
   "     ++      +------ ",
   "     ||      |+-+ |  ",
   "   /---------|| | |  ",
   "  + ========  +-+ |  ",
 ];
 
-pub static LWHL: [[&'static str, ..2], ..6] = [
+pub static LWHL: [[&'static str; 2]; 6] = [
   [
     " _|--O========O~\\-+  ",
     "//// \\_/      \\_/    ",
@@ -137,7 +137,7 @@ pub static LWHL: [[&'static str, ..2], ..6] = [
   ]
 ];
 
-pub static LCOAL: [&'static str, ..6] = [
+pub static LCOAL: [&'static str; 6] = [
   "____                 ",
   "|   \\@@@@@@@@@@@     ",
   "|    \\@@@@@@@@@@@@@_ ",
@@ -146,7 +146,7 @@ pub static LCOAL: [&'static str, ..6] = [
   "   (O)       (O)     ",
 ];
 
-pub static LCAR: [&'static str, ..6] = [
+pub static LCAR: [&'static str; 6] = [
   "____________________ ",
   "|  ___ ___ ___ ___ | ",
   "|  |_| |_| |_| |_| | ",

--- a/src/logo.rs
+++ b/src/logo.rs
@@ -1,6 +1,7 @@
 use super::Train;
 use super::data::{LOGO, LWHL, LCOAL, LCAR};
 
+#[derive(Copy)]
 pub struct Logo;
 
 impl Train for Logo {


### PR DESCRIPTION
Some syntax and interfaces changed since this was last updated.

I updated ncurses since the previous version also wouldn't build on the latest Rust.